### PR TITLE
Fixes reback in redirect

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/icon/favicon.png">
   <link rel="apple-touch-icon" type="image/png" href="/images/icon/apple-touch-icon.png">
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
-  <script> if (document.cookie.includes('logged_in=true') && window.location.href == 'https://plausible.io/') window.location.pathname = '/sites'</script>
+  <script> if (document.cookie.includes('logged_in=true') && window.location.href == 'https://plausible.io/') history.replaceState(null, '', '/sites/'); location.reload();</script>
   <script async defer type="text/javascript" src="https://plausible.io/js/plausible.js"></script>
   <script async defer src="https://testing.plausible.io/js/plausible.js"></script>
 


### PR DESCRIPTION
The Netlify redirect solution will certainly be cleaner. This way at least ensures that a user can go back to their previous page in the history stack if redirected from the landing page without getting stuck. 
I don't *think* this should cause any other issues, but honestly, if it does — I think it'd be better off just waiting for the Netlify redirect solution and reverting back to how it was before (no redirect).  