### PR TITLE
fix(nav): spelling of github

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -75,7 +75,7 @@
                       Open Source
                       </p>
                       <p class="text-sm leading-5 text-gray-500">
-                      Built openly on Github, released under the AGPL license and can be self-hosted too.
+                      Built openly on GitHub, released under the AGPL license and can be self-hosted too.
                       </p>
                     </div>
                   </a>
@@ -169,7 +169,7 @@
                   <a href="https://github.com/plausible/analytics" class="-m-3 p-3 flex items-start space-x-4 rounded-lg hover:bg-gray-50 transition ease-in-out duration-150">
                     <div class="space-y-1">
                       <p class="text-base leading-6 font-medium text-gray-900">
-                      Github Repo
+                      GitHub Repo
                       </p>
                       <p class="text-sm leading-5 text-gray-500">
                         Inspect the source code behind our product. Self-hosted Plausible is available in beta.
@@ -258,7 +258,7 @@
           <span class="block px-3 py-2 rounded-md text-base font-medium text-gray-700">Community</span>
           <a href="/blog" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- Blog</a>
           <a href="https://docs.plausible.io" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- Documentation</a>
-          <a href="https://github.com/plausible/analytics" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- Github Repo</a>
+          <a href="https://github.com/plausible/analytics" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- GitHub Repo</a>
           <a href="https://plausible.io/roadmap" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- Public Roadmap</a>
           <a href="https://plausible.io/forum" class="ml-2 mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">- Forum</a>
           <a href="/#pricing" class="mt-1 block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50 focus:outline-none focus:text-gray-900 focus:bg-gray-50 transition duration-150 ease-in-out">Pricing</a>


### PR DESCRIPTION
hey ya! loving plausible so far -- just started using it today

found a few spelling inconsistencies of "Github" on the nav bar. Suppose to be spelt with a cap H too. 

```diff
-    Built openly on Github, released under the AGPL license and can be self-hosted too.
+    Built openly on GitHub, released under the AGPL license and can be self-hosted too.
```

the one appearing in the footer looks good tho — 
https://github.com/plausible/website/blob/6d3f959a39887cc0a02616b2cd98b72730c86d40/_includes/footer.html#L91 

quick fix so here goes a PR :) 