### PR TITLE
fix left-right scrolling bug on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ layout: default
   </div>
 </div>
 
-<div class="bg-gray-100" id="pricing">
+<div class="bg-gray-100 overflow-x-hidden" id="pricing">
   <div class="pt-12 sm:pt-16 lg:pt-20">
     <div class="px-4 mx-auto max-w-screen-xl sm:px-6 lg:px-8">
       <div class="text-center">


### PR DESCRIPTION
Changes:

- Add `overflow-x-hidden` CSS class on the `<div id="pricing">` element on the homepage (fixes https://github.com/plausible/analytics/issues/1879)

We paired on this with @vinibrsl and were able to reproduce the bug in responsive design mode. The `overflow-x-hidden` class fixed the issue and it's looking good on bigger screens too.

