### PR TITLE
Remove post date from blog home page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -28,7 +28,6 @@ layout: default
 <ul class="container max-w-screen-sm mt-12">
   {%- for post in site.posts -%}
   <li class="mt-16 list-reset">
-    <time class="uppercase text-xs text-gray-500 font-bold">{{ post.date | date: "%b %-d, %Y" }}</time>
     <h2 class="mt-1 text-2xl tracking-tight font-extrabold text-gray-900 sm:leading-none md:text-3xl">
       <a href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
     </h2>


### PR DESCRIPTION
I'm trying to remove the blog post date from the main blog home page only. can someone please check if this does what I want to do without breaking anything?