### PR TITLE
Remove `pageleave` script variant

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,8 +17,7 @@
   <script
     defer
     data-domain="plausible.io"
-    src="https://plausible.io/js/script.manual.pageleave.js"
-    data-allow-fetch
+    src="https://plausible.io/js/script.manual.js"
   ></script>
   <script>
     window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) };


### PR DESCRIPTION
`pageleave` variant code is now in main script - we can remove the usage. Related: https://github.com/plausible/docs/pull/588