### PR TITLE
Align pageviews slider properly on Firefox, split style file

### DIFF
--- a/assets/css/pageviews-slider.css
+++ b/assets/css/pageviews-slider.css
@@ -1,0 +1,71 @@
+/* 
+  Styles for the monthly pageviews slider in #pricing section
+*/
+input[type="range"] {
+    vertical-align: middle;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background: #eef1f6;
+    border-radius: 3px;
+    height: 6px;
+    width: 100%;
+    margin-top: 15px;
+    margin-bottom: 15px;
+    outline: none;
+    cursor: grab;
+  }
+  
+  input[type="range"]:active {
+    cursor: grabbing;
+  }
+  
+  input[type="range"]::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: #5f48ff;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 0;
+    border-radius: 50%;
+    height: 26px;
+    width: 26px;
+  }
+
+  input[type="range"]::-moz-range-thumb {
+    background-color: #5f48ff;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 0;
+    border: none;
+    border-radius: 50%;
+    height: 26px;
+    width: 26px;
+  }
+
+  input[type="range"]::-ms-thumb {
+    background-color: #5f48ff;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 0;
+    border-radius: 50%;
+    height: 26px;
+    width: 26px;
+  }
+  
+  input[type="range"]::-moz-focus-outer {
+    border: 0;
+  }
+  
+  .bubble {
+    background: #5f48ff;
+    color: white;
+    position: absolute;
+    border-radius: 4px;
+    bottom: 35px;
+    padding: 4px 12px;
+    transform: translateX(-50%);
+  }
+  

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,6 +4,7 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "assets/css/highlight.css";
+@import "assets/css/pageviews-slider.css";
 
 
 html {
@@ -60,70 +61,6 @@ article img {
 }
 
 @tailwind utilities;
-
-input[type="range"] {
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  background: #eef1f6;
-  border-radius: 3px;
-  height: 6px;
-  width: 100%;
-  margin-top: 15px;
-  margin-bottom: 15px;
-  outline: none;
-  cursor: grab;
-}
-
-input[type="range"]:active {
-  cursor: grabbing;
-}
-
-input[type="range"]::-webkit-slider-thumb {
-  appearance: none;
-  -webkit-appearance: none;
-  background-color: #5f48ff;
-  background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
-  background-position: center;
-  background-repeat: no-repeat;
-  border: 0;
-  border-radius: 50%;
-  height: 26px;
-  width: 26px;
-}
-input[type="range"]::-moz-range-thumb {
-  background-color: #5f48ff;
-  background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
-  background-position: center;
-  background-repeat: no-repeat;
-  border: 0;
-  border: none;
-  border-radius: 50%;
-  height: 26px;
-  width: 26px;
-}
-input[type="range"]::-ms-thumb {
-  background-color: #5f48ff;
-  background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2212%22%20height%3D%228%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M8%20.5v7L12%204zM0%204l4%203.5v-7z%22%20fill%3D%22%23FFFFFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
-  background-position: center;
-  background-repeat: no-repeat;
-  border: 0;
-  border-radius: 50%;
-  height: 26px;
-  width: 26px;
-}
-input[type="range"]::-moz-focus-outer {
-  border: 0;
-}
-
-.bubble {
-  background: #5f48ff;
-  color: white;
-  position: absolute;
-  border-radius: 4px;
-  bottom: 35px;
-  padding: 4px 12px;
-  transform: translateX(-50%);
-}
 
 .twitter-icon {
   width: 1.5rem;


### PR DESCRIPTION
* Splits pageviews slider style to a separate file
* Adds "vertical-align: middle" to input[type=range], which gives it a baseline on Firefox, which fixes the issue with it being misaligned. Checked that this doesn't misalign the slider on Chrome, Edge, Safari. 