### PR TITLE
Script v2: Update dogfooding tracker URL to new format

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,7 @@
 
   <script> if (document.cookie.includes('logged_in=true') && window.location.href == 'https://plausible.io/') window.location.pathname = '/sites'</script>
   <script {% if page.author %}data-author="{{page.author}}"{% endif %}>
-  window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)},window.plausible.init=function(i){window.plausible.o=i||{}};var script=document.createElement("script");script.type="text/javascript",script.defer=!0,script.src="https://plausible.io/js/s-6_srOGVV9SLMWJ1ZpUAbG.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(script,r);
+  window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)},window.plausible.init=function(i){window.plausible.o=i||{}};var script=document.createElement("script");script.type="text/javascript",script.defer=!0,script.src="https://plausible.io/js/pa-6_srOGVV9SLMWJ1ZpUAbG.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(script,r);
   var props = {
     browser_language: navigator.language || navigator.userLanguage
   }


### PR DESCRIPTION
After https://github.com/plausible/analytics/pull/5621, the v2 script should be accessed from a new URL (although there's a fallback for old URLs ATM)