### PR TITLE
Add sticky blog table of contents and heading links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,36 +3,36 @@ layout: default
 ---
 
 <article class="container post mt-16">
-  <div class="post-header">
-  <a
-    class="text-indigo-600 uppercase text-sm tracking-wide font-black"
-    href="/blog"
-    onclick="if (document.referrer === '{{ "" | absolute_url }}' || document.referrer === '{{ "/" | absolute_url }}') { history.back(); return false; } else { return true; }"
-    >
-    &larr; All posts
-  </a>
-  <h1 class="text-3xl mt-2 tracking-tight leading-10 font-extrabold text-gray-900 sm:text-4xl sm:leading-none md:text-5xl">{{ page.title | escape }}</h1>
+  <div class="post-header max-w-screen-sm mx-auto">
+    <a
+      class="text-indigo-600 uppercase text-sm tracking-wide font-black"
+      href="/blog"
+      onclick="if (document.referrer === '{{ "" | absolute_url }}' || document.referrer === '{{ "/" | absolute_url }}') { history.back(); return false; } else { return true; }"
+      >
+      &larr; All posts
+    </a>
+    <h1 class="text-3xl mt-2 tracking-tight leading-10 font-extrabold text-gray-900 sm:text-4xl sm:leading-none md:text-5xl">{{ page.title | escape }}</h1>
 
-  <div class="mt-2">
-    <time class="uppercase text-xs text-gray-500 font-bold">{{ page.date | date: "%b %-d, %Y" }}</time>
-    {% if page.last_modified_at %}<span class="uppercase text-xs text-gray-500 font-bold">• Updated <time>{{ page.last_modified_at | date: "%b %-d, %Y" }}</time></span>{% endif %}
-    {% assign author = site.data.authors[page.author] %}
-    <span class="text-xs uppercase font-bold text-gray-500">• Written by <a class="uppercase text-xs text-indigo-600 font-bold hover:underline" href="https://twitter.com/{{author.twitter}}">{{ author.name }}</a></span>
-  </div>
+    <div class="mt-2">
+      <time class="uppercase text-xs text-gray-500 font-bold">{{ page.date | date: "%b %-d, %Y" }}</time>
+      {% if page.last_modified_at %}<span class="uppercase text-xs text-gray-500 font-bold">• Updated <time>{{ page.last_modified_at | date: "%b %-d, %Y" }}</time></span>{% endif %}
+      {% assign author = site.data.authors[page.author] %}
+      <span class="text-xs uppercase font-bold text-gray-500">• Written by <a class="uppercase text-xs text-indigo-600 font-bold hover:underline" href="https://twitter.com/{{author.twitter}}">{{ author.name }}</a></span>
+    </div>
 
-  {% if page.image %}
-    <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.image-alt | default: 'Featured image' }}" />
-  {% endif %}
+    {% if page.image %}
+      <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.image-alt | default: 'Featured image' }}" />
+    {% endif %}
   </div>
 
   <div class="post-content-layout">
     <aside class="post-toc" aria-label="Table of contents"></aside>
-    <div class="mt-8 prose post-content">
+    <div class="mt-8 prose post-content max-w-screen-sm mx-auto">
       {{ content }}
     </div>
   </div>
 
-  <div class="mt-8 post-footer">
+  <div class="mt-8 post-footer max-w-screen-sm mx-auto">
     {% assign author = site.data.authors[page.author] %}
     <span class="text-xs uppercase font-bold text-gray-500">Written by <a class="uppercase text-xs text-indigo-600 font-bold hover:underline" href="https://twitter.com/{{author.twitter}}">{{ author.name }}</a></span>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,8 +26,8 @@ layout: default
   </div>
 
   <div class="post-content-layout relative">
-    <aside class="post-toc hidden lg:absolute lg:top-8 lg:bottom-0" aria-label="Table of contents">
-      <div class="post-toc-panel sticky top-6 w-full py-2 overflow-hidden transition-all duration-200">
+    <aside class="post-toc hidden invisible lg:absolute lg:top-8 lg:bottom-0" aria-label="Table of contents">
+      <div class="post-toc-panel sticky top-6 w-full py-2 overflow-hidden">
         <div class="post-toc-title ml-3 mb-2 text-gray-500 text-xs font-bold tracking-wider uppercase">On this page</div>
       </div>
     </aside>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,8 @@
 layout: default
 ---
 
-<article class="container max-w-screen-sm mt-16">
+<article class="container post mt-16">
+  <div class="post-header">
   <a
     class="text-indigo-600 uppercase text-sm tracking-wide font-black"
     href="/blog"
@@ -22,13 +23,16 @@ layout: default
   {% if page.image %}
     <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.image-alt | default: 'Featured image' }}" />
   {% endif %}
-
-
-  <div class="mt-8 prose">
-    {{ content }}
   </div>
 
-  <div class="mt-8">
+  <div class="post-content-layout">
+    <aside class="post-toc" aria-label="Table of contents"></aside>
+    <div class="mt-8 prose post-content">
+      {{ content }}
+    </div>
+  </div>
+
+  <div class="mt-8 post-footer">
     {% assign author = site.data.authors[page.author] %}
     <span class="text-xs uppercase font-bold text-gray-500">Written by <a class="uppercase text-xs text-indigo-600 font-bold hover:underline" href="https://twitter.com/{{author.twitter}}">{{ author.name }}</a></span>
   </div>
@@ -80,6 +84,8 @@ layout: default
   });
 })();
 </script>
+
+<script type="text/javascript" src="{{ "/assets/js/blog-post.js" | relative_url }}?v={{ site.time | date:'%s' }}" defer></script>
 
 <div class="container max-w-screen-sm mb-24 flex justify-between">
   <div class="w-1/2">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <article class="container post mt-16">
-  <div class="post-header max-w-screen-sm mx-auto">
+  <div class="max-w-screen-sm mx-auto">
     <a
       class="text-indigo-600 uppercase text-sm tracking-wide font-black"
       href="/blog"
@@ -25,14 +25,18 @@ layout: default
     {% endif %}
   </div>
 
-  <div class="post-content-layout">
-    <aside class="post-toc" aria-label="Table of contents"></aside>
+  <div class="post-content-layout relative">
+    <aside class="post-toc hidden lg:absolute lg:top-8 lg:bottom-0" aria-label="Table of contents">
+      <div class="post-toc-panel sticky top-6 w-full py-2 overflow-hidden transition-all duration-200">
+        <div class="post-toc-title ml-3 mb-2 text-gray-500 text-xs font-bold tracking-wider uppercase">On this page</div>
+      </div>
+    </aside>
     <div class="mt-8 prose post-content max-w-screen-sm mx-auto">
       {{ content }}
     </div>
   </div>
 
-  <div class="mt-8 post-footer max-w-screen-sm mx-auto">
+  <div class="mt-8 max-w-screen-sm mx-auto">
     {% assign author = site.data.authors[page.author] %}
     <span class="text-xs uppercase font-bold text-gray-500">Written by <a class="uppercase text-xs text-indigo-600 font-bold hover:underline" href="https://twitter.com/{{author.twitter}}">{{ author.name }}</a></span>
   </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -36,6 +36,233 @@ pre.highlight {
   @apply p-4 pl-10 my-6 border border-gray-300;
 }
 
+.post-header,
+.post-footer,
+.post .post-content {
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.post-content-layout {
+  position: relative;
+}
+
+.post-toc {
+  display: none;
+}
+
+.post .post-content h2,
+.post .post-content h3,
+.post .post-content h4,
+.post .post-content h5,
+.post .post-content h6 {
+  position: relative;
+}
+
+.heading-anchor {
+  margin-left: 0.4em;
+  color: #a5b4fc !important;
+  font-weight: 400;
+  text-decoration: none !important;
+  opacity: 0;
+  transition: opacity 150ms ease, color 150ms ease;
+}
+
+.post .post-content h2:hover .heading-anchor,
+.post .post-content h3:hover .heading-anchor,
+.post .post-content h4:hover .heading-anchor,
+.post .post-content h5:hover .heading-anchor,
+.post .post-content h6:hover .heading-anchor,
+.heading-anchor:focus {
+  color: #4f46e5 !important;
+  opacity: 1;
+}
+
+@media (min-width: 768px) {
+  .heading-anchor {
+    position: absolute;
+    left: -1.15em;
+    margin-left: 0;
+    padding-right: 0.25em;
+  }
+}
+
+@media (min-width: 1024px) {
+  .post-content-layout.toc-ready .post-content > #markdown-toc {
+    display: none;
+  }
+
+  .post-content-layout.toc-ready .post-toc {
+    display: block;
+    position: absolute;
+    top: 2rem;
+    bottom: 0;
+    left: calc(50% - 50vw + 1.5rem);
+    width: min(13rem, calc(50vw - 22.5rem));
+  }
+
+  .post-toc-panel {
+    position: sticky;
+    top: 1.5rem;
+    width: 100%;
+    max-height: calc(100vh - 3rem);
+    padding: 0.5rem 0;
+    overflow: hidden;
+    transition: width 180ms ease, padding 180ms ease;
+  }
+
+  .post-toc-title {
+    margin: 0 0 0.5rem 0.75rem;
+    color: #6b7280;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .post-toc-list {
+    max-height: calc(100vh - 7rem);
+    margin: 0;
+    padding: 0 0 0 0.75rem;
+    overflow-y: auto;
+    border: 0;
+    border-left: 1px solid #e5e7eb;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    scrollbar-width: thin;
+    scrollbar-color: #d1d5db transparent;
+  }
+
+  .post-toc li > ol,
+  .post-toc li > ul {
+    margin: 0;
+    padding: 0.125rem 0 0.125rem 0.75rem;
+    border-left: 1px solid #e5e7eb;
+    list-style: none;
+  }
+
+  .post-toc-list {
+    padding-left: 0;
+  }
+
+  .post-toc li {
+    margin: 0.125rem 0;
+  }
+
+  .post-toc li > ol,
+  .post-toc li > ul {
+    display: none;
+  }
+
+  .post-toc li.toc-active-branch > ol,
+  .post-toc li.toc-active-branch > ul {
+    display: block;
+  }
+
+  .post-toc a {
+    display: block;
+    position: relative;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    color: #6b7280;
+    text-decoration: none;
+    transition: color 120ms ease, background-color 120ms ease;
+  }
+
+  .post-toc a:hover {
+    color: #5145cd;
+  }
+
+  .post-toc .toc-active > a {
+    color: #5145cd;
+    font-weight: 600;
+  }
+
+  .post-toc .toc-active > a::before {
+    position: absolute;
+    top: 0.25rem;
+    bottom: 0.25rem;
+    left: -0.8125rem;
+    width: 2px;
+    border-radius: 9999px;
+    background: #5850ec;
+    content: "";
+  }
+
+  .post-toc .toc-active-branch > a {
+    color: #374151;
+    font-weight: 600;
+  }
+
+  .post-toc:not(.toc-started) .post-toc-panel {
+    width: 3.25rem;
+    padding: 0.75rem;
+  }
+
+  .post-toc:not(.toc-started) .post-toc-title {
+    display: none;
+  }
+
+  .post-toc:not(.toc-started) .post-toc-list {
+    max-height: calc(100vh - 3rem);
+    padding: 0;
+    overflow: hidden;
+    border-left: 0;
+  }
+
+  .post-toc:not(.toc-started) li,
+  .post-toc:not(.toc-started) li > ol,
+  .post-toc:not(.toc-started) li > ul {
+    display: block;
+  }
+
+  .post-toc:not(.toc-started) li {
+    margin: 0.125rem 0;
+  }
+
+  .post-toc:not(.toc-started) li > ol,
+  .post-toc:not(.toc-started) li > ul {
+    padding: 0 0 0 0.3rem;
+    border-left: 0;
+  }
+
+  .post-toc:not(.toc-started) a {
+    width: 100%;
+    height: 0.35rem;
+    padding: 0;
+    overflow: hidden;
+    border-radius: 9999px;
+    background: #d1d5db;
+    color: transparent;
+    font-size: 0;
+    transition: width 150ms ease, background-color 150ms ease;
+  }
+
+  .post-toc:not(.toc-started) li li a {
+    width: 70%;
+    background: #e5e7eb;
+  }
+
+  .post-toc:not(.toc-started) .toc-active > a {
+    width: 100%;
+    background: #6875f5;
+  }
+
+  /* Laptop viewports need the image to respect the centered article gutter. */
+  .post .post-content img {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
+@media (min-width: 1280px) {
+  .post .post-content img {
+    width: 125%;
+    margin-left: -12.5%;
+  }
+}
+
 article img {
   @apply max-w-full mt-10 mb-6 rounded;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -41,14 +41,12 @@ pre.highlight {
 .post .post-content h4,
 .post .post-content h5,
 .post .post-content h6 {
-  position: relative;
+  @apply relative;
 }
 
 .post .post-content .heading-anchor {
-  @apply text-indigo-300 font-normal no-underline;
+  @apply text-indigo-300 font-normal no-underline opacity-0 transition duration-150 ease-in-out;
   margin-left: 0.4em;
-  opacity: 0;
-  transition: opacity 150ms ease, color 150ms ease;
 }
 
 .post .post-content h2:hover .heading-anchor,
@@ -57,26 +55,24 @@ pre.highlight {
 .post .post-content h5:hover .heading-anchor,
 .post .post-content h6:hover .heading-anchor,
 .post .post-content .heading-anchor:focus {
-  @apply text-indigo-600;
-  opacity: 1;
+  @apply text-indigo-600 opacity-100;
 }
 
 @screen md {
   .post .post-content .heading-anchor {
-    position: absolute;
+    @apply absolute ml-0;
     left: -1.15em;
-    margin-left: 0;
     padding-right: 0.25em;
   }
 }
 
 @screen lg {
   .post-content-layout.toc-ready .post-content > #markdown-toc {
-    display: none;
+    @apply hidden;
   }
 
   .post-content-layout.toc-ready .post-toc {
-    display: block;
+    @apply block;
     left: calc(50% - 50vw + 1.5rem);
     width: min(13rem, calc(50vw - 22.5rem));
   }
@@ -86,44 +82,33 @@ pre.highlight {
   }
 
   .post-toc-list {
+    @apply m-0 p-0 overflow-y-auto border-0 text-sm leading-snug border-l border-gray-200;
     max-height: calc(100vh - 7rem);
-    margin: 0;
-    padding: 0;
-    overflow-y: auto;
-    border: 0;
-    @apply text-sm leading-snug border-l border-gray-200;
     scrollbar-width: thin;
     scrollbar-color: #d2d6dc transparent;
   }
 
   .post-toc li > ol,
   .post-toc li > ul {
-    @apply border-l border-gray-200;
-    margin: 0;
-    padding: 0.125rem 0 0.125rem 0.75rem;
-    list-style: none;
+    @apply m-0 py-0.5 pl-3 border-l border-gray-200 list-none;
   }
 
   .post-toc li {
-    margin: 0.125rem 0;
+    @apply my-0.5;
   }
 
   .post-toc li > ol,
   .post-toc li > ul {
-    display: none;
+    @apply hidden;
   }
 
   .post-toc li.toc-active-branch > ol,
   .post-toc li.toc-active-branch > ul {
-    display: block;
+    @apply block;
   }
 
   .post-toc a {
-    @apply text-gray-500 no-underline rounded-md;
-    display: block;
-    position: relative;
-    padding: 0.375rem 0.5rem;
-    transition: color 150ms ease;
+    @apply block relative py-1.5 px-2 text-gray-500 no-underline rounded-md transition-colors duration-150 ease-in-out;
   }
 
   .post-toc a:hover {
@@ -139,13 +124,8 @@ pre.highlight {
   }
 
   .post-toc .toc-active > a::before {
-    position: absolute;
-    top: 0.25rem;
-    bottom: 0.25rem;
+    @apply absolute top-1 bottom-1 w-0.5 rounded-full bg-indigo-600;
     left: -0.8125rem;
-    width: 2px;
-    border-radius: 9999px;
-    @apply bg-indigo-600;
     content: "";
   }
 
@@ -154,62 +134,45 @@ pre.highlight {
   }
 
   .post-toc:not(.toc-started) .post-toc-panel {
-    width: 3.25rem;
-    padding: 0.75rem;
+    @apply w-13 p-3;
   }
 
   .post-toc:not(.toc-started) .post-toc-title {
-    display: none;
+    @apply hidden;
   }
 
   .post-toc:not(.toc-started) .post-toc-list {
+    @apply p-0 overflow-hidden border-l-0;
     max-height: calc(100vh - 3rem);
-    padding: 0;
-    overflow: hidden;
-    border-left: 0;
   }
 
   .post-toc:not(.toc-started) li,
   .post-toc:not(.toc-started) li > ol,
   .post-toc:not(.toc-started) li > ul {
-    display: block;
-  }
-
-  .post-toc:not(.toc-started) li {
-    margin: 0.125rem 0;
+    @apply block;
   }
 
   .post-toc:not(.toc-started) li > ol,
   .post-toc:not(.toc-started) li > ul {
-    padding: 0 0 0 0.25rem;
-    border-left: 0;
+    @apply py-0 pl-1 border-l-0;
   }
 
   .post-toc:not(.toc-started) a {
-    @apply bg-gray-300 rounded-full;
-    width: 100%;
-    height: 0.375rem;
-    padding: 0;
-    overflow: hidden;
-    color: transparent;
+    @apply w-full h-1.5 p-0 overflow-hidden text-transparent bg-gray-300 rounded-full transition-all duration-150 ease-in-out;
     font-size: 0;
-    transition: width 150ms ease, background-color 150ms ease;
   }
 
   .post-toc:not(.toc-started) li li a {
-    @apply bg-gray-200;
-    width: 70%;
+    @apply w-2/3 bg-gray-200;
   }
 
   .post-toc:not(.toc-started) .toc-active > a {
-    @apply bg-indigo-500;
-    width: 100%;
+    @apply w-full bg-indigo-500;
   }
 
   /* Laptop viewports need the image to respect the centered article gutter. */
   .post .post-content img {
-    width: 100%;
-    margin-left: 0;
+    @apply w-full ml-0;
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -36,14 +36,6 @@ pre.highlight {
   @apply p-4 pl-10 my-6 border border-gray-300;
 }
 
-.post-content-layout {
-  position: relative;
-}
-
-.post-toc {
-  display: none;
-}
-
 .post .post-content h2,
 .post .post-content h3,
 .post .post-content h4,
@@ -85,26 +77,12 @@ pre.highlight {
 
   .post-content-layout.toc-ready .post-toc {
     display: block;
-    position: absolute;
-    top: 2rem;
-    bottom: 0;
     left: calc(50% - 50vw + 1.5rem);
     width: min(13rem, calc(50vw - 22.5rem));
   }
 
   .post-toc-panel {
-    position: sticky;
-    top: 1.5rem;
-    width: 100%;
     max-height: calc(100vh - 3rem);
-    padding: 0.5rem 0;
-    overflow: hidden;
-    transition: width 200ms ease, padding 200ms ease;
-  }
-
-  .post-toc-title {
-    @apply text-gray-500 text-xs font-bold tracking-wider uppercase;
-    margin: 0 0 0.5rem 0.75rem;
   }
 
   .post-toc-list {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -108,7 +108,7 @@ pre.highlight {
   }
 
   .post-toc a {
-    @apply block relative py-1.5 px-2 text-gray-500 no-underline rounded-md transition-colors duration-150 ease-in-out;
+    @apply block relative py-1.5 px-2 text-gray-500 no-underline rounded-md;
   }
 
   .post-toc a:hover {
@@ -158,7 +158,7 @@ pre.highlight {
   }
 
   .post-toc:not(.toc-started) a {
-    @apply w-full h-1.5 p-0 overflow-hidden text-transparent bg-gray-300 rounded-full transition-all duration-150 ease-in-out;
+    @apply w-full h-1.5 p-0 overflow-hidden text-transparent bg-gray-300 rounded-full;
     font-size: 0;
   }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -36,14 +36,6 @@ pre.highlight {
   @apply p-4 pl-10 my-6 border border-gray-300;
 }
 
-.post-header,
-.post-footer,
-.post .post-content {
-  max-width: 40rem;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .post-content-layout {
   position: relative;
 }
@@ -60,11 +52,9 @@ pre.highlight {
   position: relative;
 }
 
-.heading-anchor {
+.post .post-content .heading-anchor {
+  @apply text-indigo-300 font-normal no-underline;
   margin-left: 0.4em;
-  color: #a5b4fc !important;
-  font-weight: 400;
-  text-decoration: none !important;
   opacity: 0;
   transition: opacity 150ms ease, color 150ms ease;
 }
@@ -74,13 +64,13 @@ pre.highlight {
 .post .post-content h4:hover .heading-anchor,
 .post .post-content h5:hover .heading-anchor,
 .post .post-content h6:hover .heading-anchor,
-.heading-anchor:focus {
-  color: #4f46e5 !important;
+.post .post-content .heading-anchor:focus {
+  @apply text-indigo-600;
   opacity: 1;
 }
 
-@media (min-width: 768px) {
-  .heading-anchor {
+@screen md {
+  .post .post-content .heading-anchor {
     position: absolute;
     left: -1.15em;
     margin-left: 0;
@@ -88,7 +78,7 @@ pre.highlight {
   }
 }
 
-@media (min-width: 1024px) {
+@screen lg {
   .post-content-layout.toc-ready .post-content > #markdown-toc {
     display: none;
   }
@@ -109,41 +99,31 @@ pre.highlight {
     max-height: calc(100vh - 3rem);
     padding: 0.5rem 0;
     overflow: hidden;
-    transition: width 180ms ease, padding 180ms ease;
+    transition: width 200ms ease, padding 200ms ease;
   }
 
   .post-toc-title {
+    @apply text-gray-500 text-xs font-bold tracking-wider uppercase;
     margin: 0 0 0.5rem 0.75rem;
-    color: #6b7280;
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
   }
 
   .post-toc-list {
     max-height: calc(100vh - 7rem);
     margin: 0;
-    padding: 0 0 0 0.75rem;
+    padding: 0;
     overflow-y: auto;
     border: 0;
-    border-left: 1px solid #e5e7eb;
-    font-size: 0.8125rem;
-    line-height: 1.4;
+    @apply text-sm leading-snug border-l border-gray-200;
     scrollbar-width: thin;
-    scrollbar-color: #d1d5db transparent;
+    scrollbar-color: #d2d6dc transparent;
   }
 
   .post-toc li > ol,
   .post-toc li > ul {
+    @apply border-l border-gray-200;
     margin: 0;
     padding: 0.125rem 0 0.125rem 0.75rem;
-    border-left: 1px solid #e5e7eb;
     list-style: none;
-  }
-
-  .post-toc-list {
-    padding-left: 0;
   }
 
   .post-toc li {
@@ -161,22 +141,23 @@ pre.highlight {
   }
 
   .post-toc a {
+    @apply text-gray-500 no-underline rounded-md;
     display: block;
     position: relative;
     padding: 0.375rem 0.5rem;
-    border-radius: 0.375rem;
-    color: #6b7280;
-    text-decoration: none;
-    transition: color 120ms ease, background-color 120ms ease;
+    transition: color 150ms ease;
   }
 
   .post-toc a:hover {
-    color: #5145cd;
+    @apply text-indigo-700;
+  }
+
+  .post-toc a:focus {
+    @apply text-indigo-700 outline-none shadow-outline;
   }
 
   .post-toc .toc-active > a {
-    color: #5145cd;
-    font-weight: 600;
+    @apply text-indigo-700 font-semibold;
   }
 
   .post-toc .toc-active > a::before {
@@ -186,13 +167,12 @@ pre.highlight {
     left: -0.8125rem;
     width: 2px;
     border-radius: 9999px;
-    background: #5850ec;
+    @apply bg-indigo-600;
     content: "";
   }
 
   .post-toc .toc-active-branch > a {
-    color: #374151;
-    font-weight: 600;
+    @apply text-gray-700 font-semibold;
   }
 
   .post-toc:not(.toc-started) .post-toc-panel {
@@ -223,30 +203,29 @@ pre.highlight {
 
   .post-toc:not(.toc-started) li > ol,
   .post-toc:not(.toc-started) li > ul {
-    padding: 0 0 0 0.3rem;
+    padding: 0 0 0 0.25rem;
     border-left: 0;
   }
 
   .post-toc:not(.toc-started) a {
+    @apply bg-gray-300 rounded-full;
     width: 100%;
-    height: 0.35rem;
+    height: 0.375rem;
     padding: 0;
     overflow: hidden;
-    border-radius: 9999px;
-    background: #d1d5db;
     color: transparent;
     font-size: 0;
     transition: width 150ms ease, background-color 150ms ease;
   }
 
   .post-toc:not(.toc-started) li li a {
+    @apply bg-gray-200;
     width: 70%;
-    background: #e5e7eb;
   }
 
   .post-toc:not(.toc-started) .toc-active > a {
+    @apply bg-indigo-500;
     width: 100%;
-    background: #6875f5;
   }
 
   /* Laptop viewports need the image to respect the centered article gutter. */
@@ -256,7 +235,7 @@ pre.highlight {
   }
 }
 
-@media (min-width: 1280px) {
+@screen xl {
   .post .post-content img {
     width: 125%;
     margin-left: -12.5%;

--- a/assets/js/blog-post.js
+++ b/assets/js/blog-post.js
@@ -86,6 +86,17 @@
     });
   }, { passive: true });
 
-  setTocMode();
-  setActiveHeading();
+  function revealToc() {
+    window.requestAnimationFrame(function() {
+      setTocMode();
+      setActiveHeading();
+      tocContainer.classList.remove('invisible');
+    });
+  }
+
+  if (document.readyState === 'complete') {
+    revealToc();
+  } else {
+    window.addEventListener('pageshow', revealToc, { once: true });
+  }
 })();

--- a/assets/js/blog-post.js
+++ b/assets/js/blog-post.js
@@ -19,20 +19,15 @@
   var tocContainer = document.querySelector('.post-toc');
   if (!toc || !tocContainer) return;
 
-  var title = document.createElement('div');
-  title.className = 'post-toc-title';
-  title.textContent = 'On this page';
-  var panel = document.createElement('div');
-  panel.className = 'post-toc-panel';
+  var panel = tocContainer.querySelector('.post-toc-panel');
+  if (!panel) return;
   var sidebarToc = toc.cloneNode(true);
   sidebarToc.removeAttribute('id');
   sidebarToc.querySelectorAll('[id]').forEach(function(element) {
     element.removeAttribute('id');
   });
   sidebarToc.classList.add('post-toc-list');
-  panel.appendChild(title);
   panel.appendChild(sidebarToc);
-  tocContainer.appendChild(panel);
   var contentLayout = tocContainer.closest('.post-content-layout');
   if (contentLayout) contentLayout.classList.add('toc-ready');
 

--- a/assets/js/blog-post.js
+++ b/assets/js/blog-post.js
@@ -1,0 +1,96 @@
+(function() {
+  var content = document.querySelector('.post .post-content');
+  if (!content) return;
+
+  var headings = Array.prototype.slice.call(content.querySelectorAll('h2[id], h3[id], h4[id], h5[id], h6[id]'));
+
+  headings.forEach(function(heading) {
+    if (heading.querySelector('.heading-anchor')) return;
+
+    var anchor = document.createElement('a');
+    anchor.className = 'heading-anchor';
+    anchor.href = '#' + encodeURIComponent(heading.id);
+    anchor.setAttribute('aria-label', 'Link to ' + heading.textContent.trim());
+    anchor.textContent = '#';
+    heading.appendChild(anchor);
+  });
+
+  var toc = content.querySelector('#markdown-toc');
+  var tocContainer = document.querySelector('.post-toc');
+  if (!toc || !tocContainer) return;
+
+  var title = document.createElement('div');
+  title.className = 'post-toc-title';
+  title.textContent = 'On this page';
+  var panel = document.createElement('div');
+  panel.className = 'post-toc-panel';
+  var sidebarToc = toc.cloneNode(true);
+  sidebarToc.removeAttribute('id');
+  sidebarToc.querySelectorAll('[id]').forEach(function(element) {
+    element.removeAttribute('id');
+  });
+  sidebarToc.classList.add('post-toc-list');
+  panel.appendChild(title);
+  panel.appendChild(sidebarToc);
+  tocContainer.appendChild(panel);
+  var contentLayout = tocContainer.closest('.post-content-layout');
+  if (contentLayout) contentLayout.classList.add('toc-ready');
+
+  var links = Array.prototype.slice.call(sidebarToc.querySelectorAll('a[href^="#"]'));
+  var linksById = {};
+  links.forEach(function(link) {
+    try {
+      linksById[decodeURIComponent(link.hash.slice(1))] = link;
+    } catch (e) {
+      linksById[link.hash.slice(1)] = link;
+    }
+  });
+
+  var currentId = null;
+  function setTocMode() {
+    tocContainer.classList.toggle('toc-started', window.scrollY > 32);
+  }
+
+  function setActiveHeading() {
+    var active = null;
+    var threshold = 140;
+
+    headings.forEach(function(heading) {
+      if (heading.getBoundingClientRect().top <= threshold) active = heading;
+    });
+    if (!active && headings.length) active = headings[0];
+    if (!active || active.id === currentId) return;
+
+    currentId = active.id;
+    sidebarToc.querySelectorAll('.toc-active, .toc-active-branch').forEach(function(item) {
+      item.classList.remove('toc-active', 'toc-active-branch');
+    });
+
+    var activeLink = linksById[currentId];
+    if (!activeLink) return;
+
+    var item = activeLink.closest('li');
+    if (item) {
+      item.classList.add('toc-active');
+      var parent = item.parentElement && item.parentElement.closest('li');
+      while (parent) {
+        parent.classList.add('toc-active-branch');
+        parent = parent.parentElement && parent.parentElement.closest('li');
+      }
+    }
+  }
+
+  var ticking = false;
+  window.addEventListener('scroll', function() {
+    if (ticking) return;
+    ticking = true;
+    window.requestAnimationFrame(function() {
+      setTocMode();
+      setActiveHeading();
+      ticking = false;
+    });
+  }, { passive: true });
+
+  setTocMode();
+  setActiveHeading();
+})();


### PR DESCRIPTION
## Summary

- add a sticky desktop table of contents using each post's existing Markdown TOC
- show a compact line map before scrolling, then highlight and expand the active heading branch
- add hover/focus hash links to H2-H6 headings
- preserve the inline TOC on smaller screens and when JavaScript is unavailable
- keep selectors scoped to blog posts so blog listings and other page layouts are unchanged