### PR TITLE
Add "web" before analytics on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,15 +230,15 @@ layout: default
       </p>
       <h3>Simple analytics at a glance</h3>
       <p>
-        Plausible is <a href="/simple-web-analytics">simple analytics</a>. It is easy to understand and cuts through the noise. Check your site traffic and get the essential insights on one page in one minute. Get an aggregated view of all your sites in a consolidated dashboard. There are no layers of menus and no need to build custom reports, custom dashboards or PowerPoint documents. You can even import your Google Analytics stats.
+        Plausible is <a href="/simple-web-analytics">simple web analytics</a>. It is easy to understand and cuts through the noise. Check your site traffic and get the essential insights on one page in one minute. Get an aggregated view of all your sites in a consolidated dashboard. There are no layers of menus and no need to build custom reports, custom dashboards or PowerPoint documents. You can even import your Google Analytics stats.
       </p>
       <h3>Lightweight script that keeps your site speed fast</h3>
       <p>
-      Plausible is <a href="/lightweight-web-analytics">lightweight analytics</a>. Our script is {{ site.data.site.script_ratio }} times smaller than Google Analytics. Every visitor that loads your site downloads {{ site.data.site.ga4_script_kb }}KB less JavaScript. Less data transferred means less energy used and less carbon emitted, for every visitor, every day. A site with 100,000 monthly visitors saves around 4 kg of CO2 per year by switching.
+      Plausible is <a href="/lightweight-web-analytics">lightweight web analytics</a>. Our script is {{ site.data.site.script_ratio }} times smaller than Google Analytics. Every visitor that loads your site downloads {{ site.data.site.ga4_script_kb }}KB less JavaScript. Less data transferred means less energy used and less carbon emitted, for every visitor, every day. A site with 100,000 monthly visitors saves around 4 kg of CO2 per year by switching.
       </p>
       <h3>No need for cookie banners or GDPR consent</h3>
       <p>
-      Plausible is <a href="/privacy-focused-web-analytics">privacy-friendly analytics</a> that doesn't process personal data or track individual users. No cookies, no persistent identifiers, no cross-site or cross-device tracking. Your site data is not used for any other purposes. All visitor data is exclusively processed on servers owned and operated by European companies and never leaves the EU.
+      Plausible is <a href="/privacy-focused-web-analytics">privacy-friendly web analytics</a> that doesn't process personal data or track individual users. No cookies, no persistent identifiers, no cross-site or cross-device tracking. Your site data is not used for any other purposes. All visitor data is exclusively processed on servers owned and operated by European companies and never leaves the EU.
       </p>
       <p>
       We invite you to take a look around, explore our <a href="/plausible.io">live demo</a> and <a href="/register">try Plausible</a> for free. We'd be honored to have you as a customer. Thank you.


### PR DESCRIPTION
- For letting google know what we are about and help it rank us for web analytics as well
- Heading, tagline, etc., not touched